### PR TITLE
spinner.go: Add support for windows

### DIFF
--- a/spinner.go
+++ b/spinner.go
@@ -6,9 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
-	"unsafe"
 )
 
 var (
@@ -142,32 +140,6 @@ func (spinner *Spinner) Call(methods ...func() error) error {
 	}
 
 	return nil
-}
-
-func getTerminalWidth() int {
-	term, err := os.Open("/dev/tty")
-	if err != nil {
-		term = os.Stdin
-	}
-
-	window := struct {
-		Rows    uint16
-		Columns uint16
-		X       uint16
-		Y       uint16
-	}{}
-
-	result, _, err := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		term.Fd(),
-		uintptr(syscall.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(&window)),
-	)
-	if int(result) == -1 || err != nil {
-		return 0
-	}
-
-	return int(window.Columns)
 }
 
 func getSpinnerSuffix(length int) string {

--- a/spinner_linux.go
+++ b/spinner_linux.go
@@ -1,0 +1,33 @@
+package spinner
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func getTerminalWidth() int {
+	term, err := os.Open("/dev/tty")
+	if err != nil {
+		term = os.Stdin
+	}
+
+	window := struct {
+		Rows    uint16
+		Columns uint16
+		X       uint16
+		Y       uint16
+	}{}
+
+	result, _, err := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		term.Fd(),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&window)),
+	)
+	if int(result) == -1 || err != nil {
+		return 0
+	}
+
+	return int(window.Columns)
+}

--- a/spinner_windows.go
+++ b/spinner_windows.go
@@ -1,0 +1,12 @@
+package spinner
+
+import termbox "github.com/nsf/termbox-go"
+
+func getTerminalWidth() int {
+	if err := termbox.Init(); err != nil {
+		panic(err)
+	}
+	width, _ := termbox.Size()
+	termbox.Close()
+	return width
+}


### PR DESCRIPTION
Hi @kovetskiy,

This adds initial support for windows, as the original function *getTerminalWidth()* is for Linux only.

Let me know if I should change anything.